### PR TITLE
修改隐藏提示框方式

### DIFF
--- a/local/js/lib-dialogs.js
+++ b/local/js/lib-dialogs.js
@@ -505,7 +505,7 @@ BlocklyDialogs.showStages = function(textContent){
     };
     BlocklyDialogs.showDialogForStage(textContent, origin, true, true, style, BlocklyDialogs.stopDialogKeyDown);
     BlocklyDialogs.startDialogKeyDown();
-    document.getElementById('showStageAll').onclick = function(){BlocklyDialogs.hideDialog(true);};
+    document.getElementById('dialogShadow').onclick = function(){BlocklyDialogs.hideDialog(true);};
 }
 /**
  * If the user preses enter, escape, or space, hide the dialog.


### PR DESCRIPTION
document.getElementById('dialogShadow').onclick = function(){BlocklyDialogs.hideDialog(true);};